### PR TITLE
Copilot/fix 1

### DIFF
--- a/examples/ubuntu-server.isotope
+++ b/examples/ubuntu-server.isotope
@@ -159,26 +159,10 @@ PRESS enter
 # STAGE os_configure - Live OS configuration
 STAGE os_configure
 
-## Wait for system to reboot and show login prompt
-# After reboot, Ubuntu takes time to start all services
-# Look for a more unique phrase or full prompt
-WAIT 3m FOR "ubuntu-server login:"  # Use full prompt if possible
-
-# Login with the ubuntu user we created
-TYPE ubuntu
-PRESS enter
-WAIT 2s
-TYPE ubuntu
-PRESS enter
+# Wait for shell prompt to be ready
 WAIT 5s
 
-TYPE ls
-PRESS enter
-
-# Wait for shell prompt to be ready
-WAIT 10s
-
-LOGIN ubuntu password=ubuntu host=127.0.0.1 port=22
+LOGIN ubuntu password=ubuntu host=127.0.0.1 port=20000
 
 # Update system packages
 RUN sudo -n apt-get update

--- a/examples/ubuntu-server.isotope
+++ b/examples/ubuntu-server.isotope
@@ -160,7 +160,7 @@ PRESS enter
 STAGE os_configure
 
 # Wait for shell prompt to be ready
-WAIT 5s
+WAIT 20s
 
 LOGIN ubuntu password=ubuntu host=127.0.0.1 port=20000
 


### PR DESCRIPTION
This pull request updates the `os_configure` stage in the `examples/ubuntu-server.isotope` file to streamline the login process and adjust connection parameters. The main changes remove manual login steps and update the SSH port and wait times.

Login and connection process improvements:
* Removed explicit waiting for the login prompt and manual typing of credentials, replacing them with a single `LOGIN` command for automated SSH login.
* Changed the SSH port in the `LOGIN` command from `22` to `20000` to match the new connection requirements.

Timing adjustments:
* Increased the wait time after reboot from 10 seconds to 20 seconds to ensure the shell prompt is ready.